### PR TITLE
Yarn PnP support for @pika/plugin-build-types, pika/plugin-ts-standard-pkg

### DIFF
--- a/packages/plugin-build-types/src/index.ts
+++ b/packages/plugin-build-types/src/index.ts
@@ -70,7 +70,7 @@ To generate types automatically:
     }
 
     reporter.info('no manual type definitions found, auto-generating...');
-    await execa(
+    await execa.node(
       tscBin,
       [
         '-d',

--- a/packages/plugin-ts-standard-pkg/src/index.ts
+++ b/packages/plugin-ts-standard-pkg/src/index.ts
@@ -112,7 +112,7 @@ export function manifest(newManifest) {
 
 export async function build({cwd, out, options, reporter}: BuilderOptions): Promise<void> {
   const additionalArgs = options.args || [];
-  const result = execa(
+  const result = execa.node(
     getTscBin(cwd),
     [
       '--outDir',


### PR DESCRIPTION
When trying to use `@pika/plugin-build-types` or `@pika/plugin-ts-standard-pkg` with Yarn 2 PnP, the following error is generated:

![image](https://user-images.githubusercontent.com/1242640/98893120-a7723800-2456-11eb-89a0-30e0c34e9d46.png)

This appears to happen because PnP uses a custom archive-based resolution instead of standard filesystem. `execa()` wraps `child_process.spawn`, which does not understand what to do with a path to a zip archive.

Using `execa.node()` is targeted specifically at node modules and works with PnP. Since the Typescript compiler is a JS module, the path resolves in all environments, including plug-n-play.

To test compatibility with yarn classic and npm, a [separate repo](https://github.com/grrizzly/pika-test) was created, with further testing instructions. The second and third commits show a broken and working version.

Here is a screenshot of it working in yarn 2 with changes applied:

![image](https://user-images.githubusercontent.com/1242640/98893807-2f0c7680-2458-11eb-9e95-9fcb24bfd5a3.png)
